### PR TITLE
Fix: Address character encoding issue in ImGui::FileCombo for Windows compatibility

### DIFF
--- a/src/framework/imguiutil.cpp
+++ b/src/framework/imguiutil.cpp
@@ -88,7 +88,8 @@ bool ImGui::FileCombo(const char* label, int* curr, const std::vector<std::files
         label, curr,
         [](void* data, int idx, const char** out_text) {
             auto items = reinterpret_cast<const std::vector<std::filesystem::path>*>(data);
-            *out_text = items->at(idx).c_str();
+            std::string temp_string = items->at(idx).u8string();
+            *out_text = temp_string.c_str();
             return true;
         },
         const_cast<void*>(reinterpret_cast<const void*>(&items)), items.size());


### PR DESCRIPTION
On Windows, `std::filesystem::path::c_str()` returns a `const wchar_t*` (wide character string), while on Linux/macOS it returns a `const char*` (narrow character string).

`*out_text` expects a narrow character string (i.e., `const char*`).

To ensure consistent behavior across platforms, we need to explicitly convert the `std::filesystem::path` to a UTF-8 encoded `std::string` using `u8string()` *before* calling `c_str()`. This guarantees that `c_str()` always returns a `const char*`.

The functionality should not be changed by this.


